### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Template set up with basic infrastructure for C++ projects.
 
 # Building [![Build Status](https://travis-ci.org/melinda-sw/cpp-starter-template.svg?branch=master)](https://travis-ci.org/melinda-sw/cpp-starter-template)
 * Run scripts/build.sh
-** Script supports optional configuration parameter (-c) with options Debug, RelWithDebInfo, Release
+  * Script supports optional configuration parameter (-c) with options Debug, RelWithDebInfo, Release
 


### PR DESCRIPTION
Fix typo in building instructions section of README