### PR TITLE
Disable clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ﻿---
-Checks: 'bugprone-*,cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,clang-analyzer-*,misc-*,modernize-*,-modernize-use-trailing-return-type,performance-*,portability-*,readability-*,-readability-redundant-access-specifiers,-readability-magic-numbers'
+Checks: 'bugprone-*,cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,clang-analyzer-*,misc-*,modernize-*,-modernize-use-trailing-return-type,-modernize-use-auto,performance-*,portability-*,readability-*,-readability-redundant-access-specifiers,-readability-magic-numbers,-readability-convert-member-functions-to-static'
 HeaderFilterRegex: '*'
 FormatStyle: 'file'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 include(cmake/conan.cmake)
 include(cmake/clang-format.cmake)
-include(cmake/clang-tidy.cmake)
+# include(cmake/clang-tidy.cmake)
 
 # Conan and dependencies configuration
 conan_add_remote(


### PR DESCRIPTION
- Improves the default clang-tidy configuration
- Disables running clang-tidy by default as it becomes more of a chore then a helper with 3rd party code involved