### PR TITLE
Fix Travis CI configuration references to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-bionic-10 main'
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - g++-9
@@ -28,7 +28,7 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-bionic-10 main'
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - clang-10
@@ -45,6 +45,7 @@ matrix:
         - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10"
 
 before_install:
+    - sudo apt-get update
     - eval "${MATRIX_EVAL}"
 
 script: ./ci/travis.sh


### PR DESCRIPTION
Following package source definition:
`sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-bionic-10 main'`

Causes error:
`E: The repository 'http://apt.llvm.org/xenial llvm-toolchain-bionic-10 Release' does not have a Release file.
opengl/virtual@bincrafters/stable: ERROR: while executing system_requirements(): Command 'sudo -A apt-get update' failed`

As the Travis CI is configured to run on `Bionic` not `Xenial`