### PR TITLE
Update GCC to version 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
-            - g++-9
+            - g++-10
             # Support for Conan dependency management
             - python3
             - python3-pip
@@ -22,16 +22,19 @@ matrix:
       install:
           - pip3 install conan
       env:
-        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10"
 
     - os: linux
       addons:
         apt:
           sources:
+            - ubuntu-toolchain-r-test
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - clang-10
+            # Standard library
+            - g++-10
             # Support for Conan dependency management
             - python3
             - python3-pip

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Template set up with basic infrastructure for C++ projects.
 
 ## Supported compilers
-- GCC 9
+- GCC 10
 - Clang 10
 
 # Building [![Build Status](https://travis-ci.org/melinda-sw/cpp-starter-template.svg?branch=master)](https://travis-ci.org/melinda-sw/cpp-starter-template)


### PR DESCRIPTION
- Switch to the current release of GCC
- Fix bug where Clang would use a older version of stdlibc++