### PR TITLE
Switch to Travis CI on .com domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# cpp-starter-template [![Build Status](https://travis-ci.org/melinda-sw/cpp-starter-template.svg?branch=master)](https://travis-ci.org/melinda-sw/cpp-starter-template)
+# cpp-starter-template [![Build Status](https://travis-ci.com/melinda-sw/cpp-starter-template.svg?branch=master)](https://travis-ci.com/melinda-sw/cpp-starter-template)
 Template set up with basic infrastructure for C++ projects.
 
 ## Supported compilers
 - GCC 10
 - Clang 10
 
-# Building [![Build Status](https://travis-ci.org/melinda-sw/cpp-starter-template.svg?branch=master)](https://travis-ci.org/melinda-sw/cpp-starter-template)
+# Building [![Build Status](https://travis-ci.com/melinda-sw/cpp-starter-template.svg?branch=master)](https://travis-ci.com/melinda-sw/cpp-starter-template)
 * Run scripts/build.sh
   * Script supports optional configuration parameter (-c) with options Debug, RelWithDebInfo, Release
 


### PR DESCRIPTION
- Switch to travis-ci.com instead of travis-ci.org because it's shutting down