### PR TITLE
Preserve include groups in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,7 +36,7 @@ Cpp11BracedListStyle: 'true'
 DerivePointerAlignment: 'false'
 DisableFormat: 'false'
 FixNamespaceComments: 'true'
-IncludeBlocks: Regroup
+IncludeBlocks: Preserve
 IncludeIsMainRegex: '"(.t)?$"'
 IndentCaseLabels: 'false'
 IndentPPDirectives: None


### PR DESCRIPTION
- Include groups are preserved to avoid merging own includes with
  standard library headers