### PR TITLE
Add support for AArch64 cross compilation

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Fetch dependencies
         run: |
           conan profile detect --force
-          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --build=* --settings build_type=Release
+          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --profile=conan/opt/aarch64-linux-hardening --build=* --settings build_type=Release
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Fetch dependencies
         run: |
           conan profile detect --force
-          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --profile conan/opt/linux-hardening --build=* --settings build_type=Release
+          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --build=* --settings build_type=Release
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -22,14 +22,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc]
+        compiler: [gcc, clang]
         
     steps:
       - name: Checkout repository from github
         uses: actions/checkout@v4
 
       - name: Install gcc-${{ env.GCC_VER }}
-        if:  matrix.compiler == 'gcc'
         run: |
           sudo apt-get install -y gcc-${{ env.GCC_VER }}-aarch64-linux-gnu g++-${{ env.GCC_VER }}-aarch64-linux-gnu
 
@@ -43,7 +42,7 @@ jobs:
           sudo add-apt-repository -y "deb http://apt.llvm.org/${DISTRIB_CODENAME}/ llvm-toolchain-${DISTRIB_CODENAME}-${{ env.CLANG_VER }} main"
           sudo apt-get install -y clang-${{ env.CLANG_VER }} llvm-${{ env.CLANG_VER }}
 
-          echo "CONAN_PROFILE=clang-${{ env.CLANG_VER }}" >> $GITHUB_ENV
+          echo "CONAN_PROFILE=aarch64-clang-${{ env.CLANG_VER }}" >> $GITHUB_ENV
               
       - name: Install Conan
         uses: turtlebrowser/get-conan@v1.2

--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -1,0 +1,65 @@
+name: aarch64 CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    runs-on: ubuntu-22.04
+    
+    env:
+      GCC_VER: 12
+      CLANG_VER: 17
+      
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc]
+        
+    steps:
+      - name: Checkout repository from github
+        uses: actions/checkout@v4
+
+      - name: Install gcc-${{ env.GCC_VER }}
+        if:  matrix.compiler == 'gcc'
+        run: |
+          sudo apt-get install -y gcc-${{ env.GCC_VER }}-aarch64-linux-gnu g++-${{ env.GCC_VER }}-aarch64-linux-gnu
+
+          echo "CONAN_PROFILE=aarch64-gcc-${{ env.GCC_VER }}" >> $GITHUB_ENV
+
+      - name: Install clang-${{ env.CLANG_VER }}
+        if: matrix.compiler == 'clang'
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          . /etc/lsb-release
+          sudo add-apt-repository -y "deb http://apt.llvm.org/${DISTRIB_CODENAME}/ llvm-toolchain-${DISTRIB_CODENAME}-${{ env.CLANG_VER }} main"
+          sudo apt-get install -y clang-${{ env.CLANG_VER }} llvm-${{ env.CLANG_VER }}
+
+          echo "CONAN_PROFILE=clang-${{ env.CLANG_VER }}" >> $GITHUB_ENV
+              
+      - name: Install Conan
+        uses: turtlebrowser/get-conan@v1.2
+        with:
+          version: 2.0.17
+
+      - name: Fetch dependencies
+        run: |
+          conan profile detect --force
+          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --profile conan/opt/linux-hardening --build=* --settings build_type=Release
+
+      - name: Configure CMake
+        run: |
+          cmake --preset release
+
+      - name: Build
+        run: |
+          cmake --build --preset=release
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Necessary build tools are:
   * See [installation instructions](https://docs.conan.io/2/installation.html)
 * One of supported compilers:
   * Clang-17
+  * GCC-12 for AArch64
   * GCC-13
   * Visual Studio 2022 (MSVC v193)
 
@@ -16,7 +17,7 @@ Necessary build tools are:
 ```
 conan install . --profile=conan/clang-17 --build=missing --settings build_type=Release
 ```
-* Conan profiles for supported compilers: `gcc-13`, `clang-17` and `msvc-2022`
+* Conan profiles for supported compilers: `gcc-13`, `clang-17`, `msvc-2022`, `aarch64-gcc-12`
 * Conan build types: `Release`, `Debug`
 
 ### Configure, build and test

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ with `Release` build type. This option is disabled by default.
 ```
 conan install . --profile=conan/clang-17 --profile=conan/opt/linux-hardening --build=* --settings build_type=Release
 ```
-* Conan profiles for toolchain hardening are: `linux-hardening` and `msvc-hardening`
+* Conan profiles for toolchain hardening are: `linux-hardening` and `msvc-hardening` for x86\_64 architectures and `aarch64-linux-hardening` for AArch64 architecture
 
 ### Sanitizers
 Enable sanitizers by adding an additional profile to the `conan install` command,

--- a/README.md
+++ b/README.md
@@ -9,15 +9,21 @@ Necessary build tools are:
   * See [installation instructions](https://docs.conan.io/2/installation.html)
 * One of supported compilers:
   * Clang-17
-  * GCC-12 for AArch64
   * GCC-13
   * Visual Studio 2022 (MSVC v193)
+
+### Cross compilation
+Supported architecture for cross compilation is Linux AArch64 with one of following compilers:
+* GCC-12
+* Clang-17
+
+Note that the compilation flags assume ARM Cortex-A76. Which can be changed in corresponding Conan profiles.
 
 ### Install dependencies
 ```
 conan install . --profile=conan/clang-17 --build=missing --settings build_type=Release
 ```
-* Conan profiles for supported compilers: `gcc-13`, `clang-17`, `msvc-2022`, `aarch64-gcc-12`
+* Conan profiles for supported compilers: `gcc-13`, `clang-17`, `msvc-2022`, `aarch64-gcc-12`, `aarch64-clang-17`
 * Conan build types: `Release`, `Debug`
 
 ### Configure, build and test

--- a/conan/aarch64-clang-17
+++ b/conan/aarch64-clang-17
@@ -1,0 +1,15 @@
+[settings]
+os=Linux
+arch=armv8
+compiler=clang
+compiler.cppstd=23
+compiler.libcxx=libstdc++11
+compiler.version=17
+
+[buildenv]
+CC=clang-17
+CXX=clang++-17
+
+[conf]
+tools.build:cflags+=["--target=aarch64-linux-gnu", "-mcpu=cortex-a76", "-march=armv8-a"]
+tools.build:cxxflags+=["--target=aarch64-linux-gnu", "-mcpu=cortex-a76", "-march=armv8-a"]

--- a/conan/aarch64-gcc-12
+++ b/conan/aarch64-gcc-12
@@ -10,3 +10,7 @@ compiler.version=12
 CC=aarch64-linux-gnu-gcc-12
 CXX=aarch64-linux-gnu-g++-12
 LD=aarch64-linux-gnu-ld
+
+[conf]
+tools.build:cflags+=["-mcpu=cortex-a76"]
+tools.build:cxxflags+=["-mcpu=cortex-a76"]

--- a/conan/aarch64-gcc-12
+++ b/conan/aarch64-gcc-12
@@ -1,0 +1,12 @@
+[settings]
+os=Linux
+arch=armv8
+compiler=gcc
+compiler.cppstd=23
+compiler.libcxx=libstdc++11
+compiler.version=12
+
+[buildenv]
+CC=aarch64-linux-gnu-gcc-12
+CXX=aarch64-linux-gnu-g++-12
+LD=aarch64-linux-gnu-ld

--- a/conan/opt/aarch64-linux-hardening
+++ b/conan/opt/aarch64-linux-hardening
@@ -1,0 +1,5 @@
+include(common-linux-hardening)
+
+[conf]
+tools.build:cflags+=["-mbranch-protection=standard"]
+tools.build:cxxflags+=["-mbranch-protection=standard"]

--- a/conan/opt/common-linux-hardening
+++ b/conan/opt/common-linux-hardening
@@ -1,0 +1,5 @@
+[conf]
+tools.build:cflags+=["-D_GLIBCXX_ASSERTIONS", "-U_FORTIFY_SOURCE", "-D_FORTIFY_SOURCE=2", "-fPIC", "-fstack-protector-strong"]
+tools.build:cxxflags+=["-D_GLIBCXX_ASSERTIONS", "-U_FORTIFY_SOURCE", "-D_FORTIFY_SOURCE=2", "-fPIC", "-fstack-protector-strong"]
+tools.build:sharedlinkflags+=["-z relro", "-z now", "-z noexecstack"]
+tools.build:exelinkflags+=["-pie", "-z relro", "-z now", "-z noexecstack"]

--- a/conan/opt/linux-hardening
+++ b/conan/opt/linux-hardening
@@ -1,5 +1,6 @@
+include(common-linux-hardening)
+
 [conf]
-tools.build:cflags+=["-D_GLIBCXX_ASSERTIONS", "-U_FORTIFY_SOURCE", "-D_FORTIFY_SOURCE=2", "-fPIC", "-fstack-protector-strong", "-fcf-protection", "-fstack-clash-protection"]
-tools.build:cxxflags+=["-D_GLIBCXX_ASSERTIONS", "-U_FORTIFY_SOURCE", "-D_FORTIFY_SOURCE=2", "-fPIC", "-fstack-protector-strong", "-fcf-protection", "-fstack-clash-protection"]
-tools.build:sharedlinkflags+=["-z relro", "-z now", "-z noexecstack"]
-tools.build:exelinkflags+=["-pie", "-z relro", "-z now", "-z noexecstack"]
+tools.build:cflags+=["-fcf-protection", "-fstack-clash-protection"]
+tools.build:cxxflags+=["-fcf-protection", "-fstack-clash-protection"]
+

--- a/src/cst/CMakeLists.txt
+++ b/src/cst/CMakeLists.txt
@@ -25,6 +25,8 @@ if (CST_BUILD_TESTS)
             project-options
     )
 
-    include(Catch)
-    catch_discover_tests(cst_test)
+    if (NOT CMAKE_CROSSCOMPILING)
+        include(Catch)
+        catch_discover_tests(cst_test)
+    endif()
 endif()


### PR DESCRIPTION
- Add Conan profiles `aarch64-gcc-12` and `aarch64-clang-17`
- Fix CMake to properly build when cross compiling
- Add toolchain hardening profile `aarch64-linux-hardening`