### PR TITLE
Move toolchain hardening flags to compile flags

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -52,11 +52,11 @@ jobs:
       - name: Fetch dependencies
         run: |
           conan profile detect --force
-          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --profile=conan/opt/aarch64-linux-hardening --build=* --settings build_type=Release
+          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --profile=conan/opt/${{ matrix.compiler }}-aarch64-linux-hardening --build=* --settings build_type=Release
 
       - name: Configure CMake
         run: |
-          cmake --preset release
+          cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON --preset release
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Fetch dependencies
         run: |
           conan profile detect --force
-          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --profile conan/opt/${{matrix.compiler}-linux-hardening --build=* --settings build_type=Release
+          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --profile conan/opt/${{matrix.compiler}}-linux-hardening --build=* --settings build_type=Release
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,11 @@ jobs:
       - name: Fetch dependencies
         run: |
           conan profile detect --force
-          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --profile conan/opt/linux-hardening --build=* --settings build_type=Release
+          conan install . --profile=conan/${{ env.CONAN_PROFILE }} --profile conan/opt/${{matrix.compiler}-linux-hardening --build=* --settings build_type=Release
 
       - name: Configure CMake
         run: |
-          cmake --preset release
+          cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON --preset release
 
       - name: Build
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.27)
 
+cmake_policy(SET CMP0083 NEW)
+
 project(cst VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -11,6 +13,16 @@ option(CST_ENABLE_CPPCHECK "Enable cppcheck in build" OFF)
 option(CST_ENABLE_IWYU "Enable include-what-you-use in build" OFF)
 
 find_package(fmt REQUIRED)
+
+if (CMAKE_POSITION_INDEPENDENT_CODE)
+    include(CheckPIESupported)
+    check_pie_supported(OUTPUT_VARIABLE pie_supported LANGUAGES CXX)
+    if(NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
+        message(WARNING "PIE is not supported at link time: ${pie_supported}.\n PIE link options will not be passed to linker.")
+    else()
+        message(STATUS "PIE flags enabled for executable targets.")
+    endif()
+endif()
 
 if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     include(CTest)

--- a/README.md
+++ b/README.md
@@ -54,12 +54,21 @@ disabled by default.
 ### Toolchain hardening
 Enable toolchain security hardening compiler options, by adding an additional
 profile to the `conan install` command, together with `--build=*` to recompile
-dependencies with hardening enabled. The hardening options should only be used
+dependencies with hardening enabled. Also enable CMAKE\_POSITION\_INDEPENDENT\_CODE
+variable during CMake configure. The harddning options should only be used
 with `Release` build type. This option is disabled by default.
 ```
 conan install . --profile=conan/clang-18 --profile=conan/opt/linux-hardening --build=* --settings build_type=Release
+cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON --preset release
 ```
-* Conan profiles for toolchain hardening are: `linux-hardening` and `msvc-hardening` for x86\_64 architectures and `aarch64-linux-hardening` for AArch64 architecture
+For x86\_64 architecture toolchain hardening Conan profiles are:
+* `gcc-linux-hardening`
+* `clang-linux-hardening`
+* `msvc-hardening`
+
+For AArch64 architecture toolchain hardening Conan profiles are:
+* `gcc-aarch64-linux-hardening`
+* `clang-aarch64-linux-hardening`
 
 ### Sanitizers
 Enable sanitizers by adding an additional profile to the `conan install` command,

--- a/conan/opt/clang-aarch64-linux-hardening
+++ b/conan/opt/clang-aarch64-linux-hardening
@@ -1,0 +1,6 @@
+include(aarch64-linux-hardening)
+
+[conf]
+tools.build:cflags+=["--start-no-unused-arguments", "-Wl,-z,relro,-z,now,-z,noexecstack", "--end-no-unused-arguments"]
+tools.build:cxxflags+=["--start-no-unused-arguments", "-Wl,-z,relro,-z,now,-z,noexecstack", "--end-no-unused-arguments"]
+

--- a/conan/opt/clang-linux-hardening
+++ b/conan/opt/clang-linux-hardening
@@ -1,0 +1,6 @@
+include(linux-hardening)
+
+[conf]
+tools.build:cflags+=["--start-no-unused-arguments", "-Wl,-z,relro,-z,now,-z,noexecstack", "--end-no-unused-arguments"]
+tools.build:cxxflags+=["--start-no-unused-arguments", "-Wl,-z,relro,-z,now,-z,noexecstack", "--end-no-unused-arguments"]
+

--- a/conan/opt/common-linux-hardening
+++ b/conan/opt/common-linux-hardening
@@ -1,5 +1,3 @@
 [conf]
 tools.build:cflags+=["-D_GLIBCXX_ASSERTIONS", "-U_FORTIFY_SOURCE", "-D_FORTIFY_SOURCE=2", "-fPIC", "-fstack-protector-strong"]
 tools.build:cxxflags+=["-D_GLIBCXX_ASSERTIONS", "-U_FORTIFY_SOURCE", "-D_FORTIFY_SOURCE=2", "-fPIC", "-fstack-protector-strong"]
-tools.build:sharedlinkflags+=["-z relro", "-z now", "-z noexecstack"]
-tools.build:exelinkflags+=["-pie", "-z relro", "-z now", "-z noexecstack"]

--- a/conan/opt/gcc-aarch64-linux-hardening
+++ b/conan/opt/gcc-aarch64-linux-hardening
@@ -1,0 +1,6 @@
+include(aarch64-linux-hardening)
+
+[conf]
+tools.build:cflags+=["-Wl,-z,relro,-z,now,-z,noexecstack"]
+tools.build:cxxflags+=["-Wl,-z,relro,-z,now,-z,noexecstack"]
+

--- a/conan/opt/gcc-linux-hardening
+++ b/conan/opt/gcc-linux-hardening
@@ -1,0 +1,6 @@
+include(linux-hardening)
+
+[conf]
+tools.build:cflags+=["-Wl,-z,relro,-z,now,-z,noexecstack"]
+tools.build:cxxflags+=["-Wl,-z,relro,-z,now,-z,noexecstack"]
+


### PR DESCRIPTION
Mapping between `tools.build:sharedlinkflags` and `tools.build:exelinkflags` Conan options and build systems of dependencies isn't perfect. Some of them get confused and packages don't build, specifying linker flags in command line for the compiler seems to work on all.

With this `-pie` isn't set by Conan profile anymore, therefore this functionality is moved to CMake instead.