### PR TITLE
Improve CI actions cache

### DIFF
--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -10,8 +10,8 @@ inputs:
     description: 'Target architecture'
     required: false
     default: 'x64'
-  build-type:
-    description: 'Used build type'
+  profile:
+    description: 'Used profile'
     required: true
   shell:
     description: 'Used shell for executing commands'
@@ -21,9 +21,7 @@ inputs:
     description: 'Version to install'
     required: false
     default: 2.2.1
-outputs:
-  conan-profile:
-    value: conan/${{inputs.arch == 'aarch64' && 'aarch64-' || ''}}${{ inputs.compiler }}-${{ inputs.compiler-version }}
+
 runs:
   using: 'composite'
   steps:
@@ -37,13 +35,15 @@ runs:
       run: |
         conan config install conan/global.conf
 
-    - name: Get Conan cache location
+    - name: Set environment variables
       if: ${{ runner.os == 'Linux' }}
       shell: ${{ inputs.shell }}
       run: |
           echo "CONAN_CACHE_LOCATION=$(conan config home)" >> $GITHUB_ENV
+          echo "COMPILER_NAME=${{ inputs.compiler }}" >> $GITHUB_ENV
+          echo "COMPILER_VER=${{ inputs.compiler-version }}" >> $GITHUB_ENV
 
-    - name: Get Conan cache location
+    - name: Set environment variables
       if: ${{ runner.os == 'Windows' }}
       shell: ${{ inputs.shell }}
       run: |
@@ -54,10 +54,14 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ env.CONAN_CACHE_LOCATION }}/p
-        key: ${{ github.job }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ hashFiles('conanfile.py') }}
+        key: ${{ inputs.compiler }}-${{ inputs.profile }}-${{ hashFiles('conanfile.py') }}
         
     - name: Detect default profile
       shell: ${{ inputs.shell }}
       run: |
         conan profile detect --force
 
+    - name: Build all dependencies
+      shell: ${{ inputs.shell }}
+      run: |
+        conan install . --build=missing --profile=ci/conan/${{ inputs.profile }}

--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -47,11 +47,7 @@ jobs:
            compiler: ${{ matrix.compiler }}
            arch: 'aarch64'
            compiler-version: ${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }}
-           build-type: Release             
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/opt/${{ matrix.compiler }}-aarch64-linux-hardening --build=missing --settings build_type=Release
+           profile: aarch64-linux-hardened             
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,7 @@ jobs:
         with:
           compiler: ${{ matrix.compiler }}
           compiler-version: ${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }}
-          build-type: Release
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile conan/opt/linux-hardening --build=missing --settings build_type=Release
+          profile: linux-hardened
 
       - name: Configure CMake
         run: |
@@ -83,11 +79,7 @@ jobs:
         with:
           compiler: msvc
           compiler-version: 2022
-          build-type: Release
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/opt/msvc-hardening --build=missing --settings build_type=Release
+          profile: msvc-hardened
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -36,11 +36,7 @@ jobs:
         with:
           compiler: clang
           compiler-version: ${{ env.CLANG_VER }}
-          build-type: Release
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/opt/linux-address-sanitizer --profile=conan/opt/linux-leak-sanitizer --profile=conan/opt/linux-undefined-sanitizer --build=missing --settings build_type=Release
+          profile: clang-asan-leak-undefined
 
       - name: Configure CMake
         run: |
@@ -76,11 +72,7 @@ jobs:
         with:
           compiler: gcc
           compiler-version: ${{ env.GCC_VER }}
-          build-type: Release
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/opt/linux-thread-sanitizer --build=missing --settings build_type=Release
+          profile: gcc-tsan
 
       - name: Configure CMake
         run: |
@@ -114,11 +106,7 @@ jobs:
         with:
           compiler: msvc
           compiler-version: 2022
-          build-type: Release
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/opt/msvc-address-sanitizer --build=missing --settings build_type=Release
+          profile: msvc-asan
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -39,11 +39,7 @@ jobs:
         with:
           compiler: clang
           compiler-version: ${{ env.CLANG_VER }}
-          build-type: Debug
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --build=missing --settings build_type=Debug
+          profile: static-analysis
 
       - name: Configure CMake
         run: |
@@ -84,11 +80,7 @@ jobs:
         with:
           compiler: clang
           compiler-version: ${{ env.CLANG_VER }}
-          build-type: Debug
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --build=missing --settings build_type=Debug
+          profile: static-analysis
 
       - name: Configure CMake
         run: |
@@ -120,11 +112,7 @@ jobs:
         with:
           compiler: gcc
           compiler-version: ${{ env.GCC_VER }}
-          build-type: Debug             
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --build=missing --settings build_type=Debug
+          profile: static-analysis             
 
       - name: Configure CMake
         run: |
@@ -159,11 +147,7 @@ jobs:
         with:
           compiler: gcc
           compiler-version: ${{ env.GCC_VER }}
-          build-type: Debug             
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --build=missing --settings build_type=Debug
+          profile: static-analysis             
 
       - name: Configure CMake
         run: |
@@ -196,11 +180,7 @@ jobs:
         with:
           compiler: msvc
           compiler-version: 2022
-          build-type: Debug
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --build=missing --settings build_type=Debug
+          profile: msvc-analyze
 
       - name: Configure CMake
         run: |

--- a/ci/conan/aarch64-linux-hardened
+++ b/ci/conan/aarch64-linux-hardened
@@ -1,0 +1,6 @@
+include(../../conan/aarch64-{{ os.getenv("COMPILER_NAME") }}-{{ os.getenv("COMPILER_VER") }})
+include(../../conan/opt/{{ os.getenv("COMPILER_NAME") }}-aarch64-linux-hardening)
+
+[settings]
+build_type=Release
+

--- a/ci/conan/clang-asan-leak-undefined
+++ b/ci/conan/clang-asan-leak-undefined
@@ -1,0 +1,9 @@
+include(../../conan/clang-{{ os.getenv("CLANG_VER") }})
+include(../../conan/dependencies)
+include(../../conan/opt/linux-address-sanitizer)
+include(../../conan/opt/linux-leak-sanitizer)
+include(../../conan/opt/linux-undefined-sanitizer)
+
+[settings]
+build_type=Release
+

--- a/ci/conan/clang-asan-leak-undefined
+++ b/ci/conan/clang-asan-leak-undefined
@@ -1,5 +1,4 @@
 include(../../conan/clang-{{ os.getenv("CLANG_VER") }})
-include(../../conan/dependencies)
 include(../../conan/opt/linux-address-sanitizer)
 include(../../conan/opt/linux-leak-sanitizer)
 include(../../conan/opt/linux-undefined-sanitizer)

--- a/ci/conan/gcc-tsan
+++ b/ci/conan/gcc-tsan
@@ -1,0 +1,7 @@
+include(../../conan/gcc-{{ os.getenv("GCC_VER") }})
+include(../../conan/dependencies)
+include(../../conan/opt/linux-thread-sanitizer)
+
+[settings]
+build_type=Release
+

--- a/ci/conan/gcc-tsan
+++ b/ci/conan/gcc-tsan
@@ -1,5 +1,4 @@
 include(../../conan/gcc-{{ os.getenv("GCC_VER") }})
-include(../../conan/dependencies)
 include(../../conan/opt/linux-thread-sanitizer)
 
 [settings]

--- a/ci/conan/linux-hardened
+++ b/ci/conan/linux-hardened
@@ -1,0 +1,7 @@
+include(../../conan/{{ os.getenv("COMPILER_NAME") }}-{{ os.getenv("COMPILER_VER") }})
+include(../../conan/dependencies)
+include(../../conan/opt/{{ os.getenv("COMPILER_NAME") }}-linux-hardening)
+
+[settings]
+build_type=Release
+

--- a/ci/conan/linux-hardened
+++ b/ci/conan/linux-hardened
@@ -1,5 +1,4 @@
 include(../../conan/{{ os.getenv("COMPILER_NAME") }}-{{ os.getenv("COMPILER_VER") }})
-include(../../conan/dependencies)
 include(../../conan/opt/{{ os.getenv("COMPILER_NAME") }}-linux-hardening)
 
 [settings]

--- a/ci/conan/msvc-analyze
+++ b/ci/conan/msvc-analyze
@@ -1,0 +1,6 @@
+include(../../conan/msvc-2022)
+include(../../conan/dependencies)
+
+[settings]
+build_type=Debug
+

--- a/ci/conan/msvc-analyze
+++ b/ci/conan/msvc-analyze
@@ -1,5 +1,4 @@
 include(../../conan/msvc-2022)
-include(../../conan/dependencies)
 
 [settings]
 build_type=Debug

--- a/ci/conan/msvc-asan
+++ b/ci/conan/msvc-asan
@@ -1,0 +1,7 @@
+include(../../conan/msvc-2022)
+include(../../conan/dependencies)
+include(../../conan/opt/msvc-address-sanitizer)
+
+[settings]
+build_type=Release
+

--- a/ci/conan/msvc-asan
+++ b/ci/conan/msvc-asan
@@ -1,5 +1,4 @@
 include(../../conan/msvc-2022)
-include(../../conan/dependencies)
 include(../../conan/opt/msvc-address-sanitizer)
 
 [settings]

--- a/ci/conan/msvc-hardened
+++ b/ci/conan/msvc-hardened
@@ -1,0 +1,7 @@
+include(../../conan/msvc-2022)
+include(../../conan/dependencies)
+include(../../conan/opt/msvc-hardening)
+
+[settings]
+build_type=Release
+

--- a/ci/conan/msvc-hardened
+++ b/ci/conan/msvc-hardened
@@ -1,5 +1,4 @@
 include(../../conan/msvc-2022)
-include(../../conan/dependencies)
 include(../../conan/opt/msvc-hardening)
 
 [settings]

--- a/ci/conan/static-analysis
+++ b/ci/conan/static-analysis
@@ -1,0 +1,6 @@
+include(../../conan/{{ os.getenv("COMPILER_NAME")}}-{{ os.getenv("COMPILER_VER") }})
+include(../../conan/dependencies)
+
+[settings]
+build_type=Debug
+

--- a/ci/conan/static-analysis
+++ b/ci/conan/static-analysis
@@ -1,5 +1,4 @@
 include(../../conan/{{ os.getenv("COMPILER_NAME")}}-{{ os.getenv("COMPILER_VER") }})
-include(../../conan/dependencies)
 
 [settings]
 build_type=Debug


### PR DESCRIPTION
- Add predefined profiles for CI invocations
- Invoke `conan install` only once for all dependencies with correct profile
- Group  action caches per compiler and profile