### PR TITLE
Fix llvm-dev and clang-tidy being installed always

### DIFF
--- a/.github/actions/install-clang/action.yml
+++ b/.github/actions/install-clang/action.yml
@@ -7,11 +7,9 @@ inputs:
   clang-tidy:
     description: 'Install clang-tidy'
     required: false
-    default: false
   dev:
     description: 'Install dev packages'
     required: false
-    default: false
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
Default values of input variables are actually strings https://stackoverflow.com/questions/76292948/github-action-boolean-input-with-default-value