### PR TITLE
Add Clang-19 on Windows

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -52,5 +52,5 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build --preset=release
+          cmake --build --preset release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,19 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build --preset=release
+          cmake --build --preset release
       
       - name: Test
         run: |
           ctest --preset release
 
-  windows:
-    runs-on: windows-2022
+  windows-msvc:
+    runs-on: windows-2025
+
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [msvc-amd64-windows-hardened]
 
     steps:
       - name: Initialize
@@ -72,7 +77,7 @@ jobs:
         id: setup-conan
         uses: ./.github/actions/setup-conan
         with:
-          profile: msvc-amd64-windows-hardened
+          profile: ${{ matrix.profile }}
 
       - name: Configure CMake
         run: |
@@ -80,9 +85,57 @@ jobs:
           
       - name: Build
         run: |
-          cmake --build --preset=multi-release
+          cmake --build --preset multi-release
 
       - name: Test
         run: |
           ctest --preset multi-release
 
+      - name: Install
+        run: |
+          cmake --install build --config Release
+          
+  windows-clang:
+    runs-on: windows-2025
+    
+    env:
+      CLANG_VER: 19
+      
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [clang-amd64-windows-hardened]
+
+    steps:
+      - name: Initialize
+        run: |
+          git config --global core.autocrlf input
+          
+      - name: Checkout repository from github
+        uses: actions/checkout@v4
+
+      - name: Install Ninja
+        run: |
+          choco install ninja
+          
+      - name: Setup Conan
+        id: setup-conan
+        uses: ./.github/actions/setup-conan
+        with:
+          profile: ${{ matrix.profile }}
+
+      - name: Configure CMake
+        run: |
+          cmake -G=Ninja --preset release
+          
+      - name: Build
+        run: |
+          cmake --build --preset release
+
+      - name: Test
+        run: |
+          ctest --preset release
+
+      - name: Install
+        run: |
+          cmake --install build/Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,6 @@ jobs:
       - name: Test
         run: |
           ctest --preset multi-release
-
-      - name: Install
-        run: |
-          cmake --install build --config Release
           
   windows-clang:
     runs-on: windows-2025
@@ -135,7 +131,3 @@ jobs:
       - name: Test
         run: |
           ctest --preset release
-
-      - name: Install
-        run: |
-          cmake --install build/Release

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -35,15 +35,15 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake --preset release
+          cmake --preset relwithdebinfo
 
       - name: Build
         run: |
-          cmake --build --preset=release
+          cmake --build --preset relwithdebinfo
 
       - name: Test
         run: |
-          ctest --preset release
+          ctest --preset relwithdebinfo
 
   gcc-tsan:
     runs-on: ubuntu-24.04
@@ -66,18 +66,18 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake --preset release
+          cmake --preset relwithdebinfo
 
       - name: Build
         run: |
-          cmake --build --preset=release
+          cmake --build --preset relwithdebinfo
 
       - name: Test
         run: |
-          ctest --preset release
+          ctest --preset relwithdebinfo
 
   msvc-asan:
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     steps:
       - name: Initialize
@@ -99,10 +99,10 @@ jobs:
           
       - name: Build
         run: |
-          cmake --build --preset=multi-release
+          cmake --build --preset multi-relwithdebinfo
 
       - name: Test
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64
-          ctest --preset multi-release
+          ctest --preset multi-relwithdebinfo

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build --preset=debug
+          cmake --build --preset debug
 
   iwyu:
     runs-on: ubuntu-24.04
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build --preset=debug
+          cmake --build --preset debug
 
   gcc-analyzer:
     runs-on: ubuntu-24.04
@@ -105,7 +105,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build --preset=debug
+          cmake --build --preset debug
 
   cppcheck:
     runs-on: ubuntu-24.04
@@ -135,13 +135,10 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build --preset=debug
+          cmake --build --preset debug
 
   msvc-analyze:
-    runs-on: windows-2022
-
-    env:
-      CONAN_PROFILE: msvc-2022
+    runs-on: windows-2025
 
     steps:
       - name: Initialize
@@ -163,5 +160,5 @@ jobs:
           
       - name: Build
         run: |
-          cmake --build --preset=multi-debug
+          cmake --build --preset multi-debug
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Necessary build tools are:
 * Conan 2.8 or higher
   * See [installation instructions](https://docs.conan.io/2/installation.html)
 * One of supported compilers:
-  * Clang-19 (libstdc++ and libc++)
+  * Clang-19 (libstdc++ or libc++)
   * GCC-14
   * Visual Studio 2022 (MSVC v194)
+* Ninja (if using Clang on Windows)
 
 ### Cross compilation
 Supported architecture for cross compilation is Linux AArch64 with one of following compilers:
@@ -29,7 +30,7 @@ conan install . --profile=conan/clang-19-libstdcxx-amd64-linux --build=missing -
 ### Configure, build and test
 ```
 cmake --preset release
-cmake --build --preset=release
+cmake --build --preset release
 ```
 Disable building of tests by:
 * Adding `--conf tools.build:skip_test=True` to `conan install` command
@@ -58,12 +59,13 @@ dependencies with hardening enabled. Also enable CMAKE\_POSITION\_INDEPENDENT\_C
 variable during CMake configure. The hardening options should only be used
 with `Release` build type. This option is disabled by default.
 ```
-conan install . --profile=conan/clang-18-libstdcxx-amd64-linux --profile=conan/opt/clang-amd64-linux-hardening --build=* --settings build_type=Release
+conan install . --profile=conan/clang-19-libstdcxx-amd64-linux --profile=conan/opt/clang-amd64-linux-hardening --build=* --settings build_type=Release
 cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON --preset release
 ```
 Predefined toolchain hardening profiles are located in `conan/opt`:
 * `clang-amd64-linux-hardening`
 * `gcc-amd64-linux-hardening`
+* `clang-amd64-windows-hardening`
 * `msvc-amd64-windows-hardening`
 * `gcc-aarch64-linux-hardening`
 * `clang-aarch64-linux-hardening`

--- a/ci/conan/clang-amd64-windows-hardened
+++ b/ci/conan/clang-amd64-windows-hardened
@@ -1,0 +1,6 @@
+include(../../conan/clang-{{ os.getenv("CLANG_VER") }}-amd64-windows)
+include(../../conan/opt/clang-amd64-windows-hardening)
+include(../../conan/opt/arch-amd64-v3)
+
+[settings]
+build_type=Release

--- a/ci/conan/clang-libcxx-amd64-linux-hardened
+++ b/ci/conan/clang-libcxx-amd64-linux-hardened
@@ -1,5 +1,6 @@
 include(../../conan/clang-{{ os.getenv("CLANG_VER") }}-libcxx-amd64-linux)
 include(../../conan/opt/clang-amd64-linux-hardening)
+include(../../conan/opt/arch-amd64-v3)
 
 [settings]
 build_type=Release

--- a/ci/conan/clang-libstdcxx-amd64-linux-asan-leak-undefined
+++ b/ci/conan/clang-libstdcxx-amd64-linux-asan-leak-undefined
@@ -2,7 +2,8 @@ include(../../conan/clang-{{ os.getenv("CLANG_VER") }}-libstdcxx-amd64-linux)
 include(../../conan/opt/linux-address-sanitizer)
 include(../../conan/opt/linux-leak-sanitizer)
 include(../../conan/opt/linux-undefined-sanitizer)
+include(../../conan/opt/arch-amd64-v3)
 
 [settings]
-build_type=Release
+build_type=RelWithDebInfo
 

--- a/ci/conan/clang-libstdcxx-amd64-linux-hardened
+++ b/ci/conan/clang-libstdcxx-amd64-linux-hardened
@@ -1,5 +1,6 @@
 include(../../conan/clang-{{ os.getenv("CLANG_VER") }}-libstdcxx-amd64-linux)
 include(../../conan/opt/clang-amd64-linux-hardening)
+include(../../conan/opt/arch-amd64-v3)
 
 [settings]
 build_type=Release

--- a/ci/conan/clang-libstdcxx-amd64-linux-static-analysis
+++ b/ci/conan/clang-libstdcxx-amd64-linux-static-analysis
@@ -1,4 +1,5 @@
 include(../../conan/clang-{{ os.getenv("CLANG_VER") }}-libstdcxx-amd64-linux)
+include(../../conan/opt/arch-amd64-v3)
 
 [settings]
 build_type=Debug

--- a/ci/conan/gcc-amd64-linux-hardened
+++ b/ci/conan/gcc-amd64-linux-hardened
@@ -1,5 +1,6 @@
 include(../../conan/gcc-{{ os.getenv("GCC_VER") }}-amd64-linux)
 include(../../conan/opt/gcc-amd64-linux-hardening)
+include(../../conan/opt/arch-amd64-v3)
 
 [settings]
 build_type=Release

--- a/ci/conan/gcc-amd64-linux-static-analysis
+++ b/ci/conan/gcc-amd64-linux-static-analysis
@@ -1,4 +1,5 @@
 include(../../conan/gcc-{{ os.getenv("GCC_VER") }}-amd64-linux)
+include(../../conan/opt/arch-amd64-v3)
 
 [settings]
 build_type=Debug

--- a/ci/conan/gcc-amd64-linux-tsan
+++ b/ci/conan/gcc-amd64-linux-tsan
@@ -1,6 +1,7 @@
 include(../../conan/gcc-{{ os.getenv("GCC_VER") }}-amd64-linux)
 include(../../conan/opt/linux-thread-sanitizer)
+include(../../conan/opt/arch-amd64-v3)
 
 [settings]
-build_type=Release
+build_type=RelWithDebInfo
 

--- a/ci/conan/msvc-amd64-windows-asan
+++ b/ci/conan/msvc-amd64-windows-asan
@@ -2,5 +2,5 @@ include(../../conan/msvc-2022-amd64-windows)
 include(../../conan/opt/msvc-amd64-windows-address-sanitizer)
 
 [settings]
-build_type=Release
+build_type=RelWithDebInfo
 

--- a/ci/conan/msvc-amd64-windows-hardened
+++ b/ci/conan/msvc-amd64-windows-hardened
@@ -3,4 +3,3 @@ include(../../conan/opt/msvc-amd64-windows-hardening)
 
 [settings]
 build_type=Release
-

--- a/conan/clang-19-amd64-windows
+++ b/conan/clang-19-amd64-windows
@@ -1,0 +1,15 @@
+[settings]
+os=Windows
+arch=x86_64
+compiler=clang
+compiler.version=19
+compiler.cppstd=23
+compiler.runtime=dynamic
+compiler.runtime_version=v144
+
+[buildenv]
+CC=clang
+CXX=clang++
+
+[conf]
+tools.cmake.cmaketoolchain:generator=Ninja

--- a/conan/opt/arch-amd64-v3
+++ b/conan/opt/arch-amd64-v3
@@ -1,4 +1,3 @@
 [conf]
 tools.build:cflags+=["-march=x86-64-v3", "-mpclmul"]
 tools.build:cxxflags+=["-march=x86-64-v3", "-mpclmul"]
-

--- a/conan/opt/arch-amd64-v3
+++ b/conan/opt/arch-amd64-v3
@@ -1,0 +1,4 @@
+[conf]
+tools.build:cflags+=["-march=x86-64-v3", "-mpclmul"]
+tools.build:cxxflags+=["-march=x86-64-v3", "-mpclmul"]
+

--- a/conan/opt/arch-native
+++ b/conan/opt/arch-native
@@ -1,4 +1,3 @@
 [conf]
 tools.build:cflags+=["-march=native", "-mtune=native"]
 tools.build:cxxflags+=["-march=native", "-mtune=native"]
-

--- a/conan/opt/arch-native
+++ b/conan/opt/arch-native
@@ -1,0 +1,4 @@
+[conf]
+tools.build:cflags+=["-march=native", "-mtune=native"]
+tools.build:cxxflags+=["-march=native", "-mtune=native"]
+

--- a/conan/opt/clang-amd64-windows-hardening
+++ b/conan/opt/clang-amd64-windows-hardening
@@ -1,0 +1,5 @@
+[conf]
+tools.build:cflags+=["-fstack-protector-strong","-Xclang", "-cfguard"]
+tools.build:cxxflags+=["-fstack-protector-strong","-Xclang", "-cfguard"]
+tools.build:sharedlinkflags+=["-Xlinker", "/DYNAMICBASE", "-Xlinker", "/NXCOMPAT", "-Xlinker", "/CETCOMPAT", "-Xlinker", "/GUARD:CF"]
+tools.build:exelinkflags+=["-Xlinker", "/DYNAMICBASE", "-Xlinker", "/NXCOMPAT","-Xlinker",  "/CETCOMPAT", "-Xlinker", "/GUARD:CF"]

--- a/conan/opt/msvc-amd64-windows-hardening
+++ b/conan/opt/msvc-amd64-windows-hardening
@@ -1,5 +1,5 @@
 [conf]
 tools.build:cflags+=["/sdl", "/guard:cf"] 
 tools.build:cxxflags+=["/sdl", "/guard:cf"]
-tools.build:sharedlinkflags+=["/DYNAMICBASE", "/NXCOMPAT", "/CETCOMPAT"]
-tools.build:exelinkflags+=["/DYNAMICBASE", "/NXCOMPAT", "/CETCOMPAT"]
+tools.build:sharedlinkflags+=["/DYNAMICBASE", "/NXCOMPAT", "/CETCOMPAT", "/GUARD:CF"]
+tools.build:exelinkflags+=["/DYNAMICBASE", "/NXCOMPAT", "/CETCOMPAT", "/GUARD:CF"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class CSTConan(ConanFile):
     exports_sources = "cmake", "src", "CMakeLists.txt", "LICENSE"
 
     def requirements(self):
-        self.requires("fmt/11.1.1")
+        self.requires("fmt/11.1.3")
 
     def build_requirements(self):
         self.tool_requires("cmake/[^3.27]")

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -50,7 +50,6 @@
   { symbol: [ "std::pair", private, "<utility>", public ] },
   { symbol: [ "std::vector", private, "<vector>", public ] },
 
-
   # libc++ aliases
   { include: [ "<__fwd/fstream.h>", private, "<fstream>", public ] },
   { include: [ "<__fwd/ios.h>", private, "<ios>", public ] },

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -40,13 +40,16 @@
   { include: [ "<bits/types/time_t.h>", private, "<time.h>", public ] },
   { include: [ "<bits/utility.h>", private, "<utility>", public ] },
   { include: [ "<__stdarg_va_arg.h>", private, "<cstdarg>", public ] },
+  { symbol: [ "std::filesystem::file_time_type", private, "<filesystem>", public ] },
   { symbol: [ "std::ranges::__find_if_fn", private, "<algorithm>", public ] },
   { symbol: [ "std::ranges::__find_fn", private, "<algorithm>", public ] },
   { symbol: [ "std::ranges::__fill_fn", private, "<algorithm>", public ] },
   { symbol: [ "std::ranges::find_if", private, "<algorithm>", public ] },
   { symbol: [ "std::ranges::find", private, "<algorithm>", public ] },
   { symbol: [ "std::ranges::fill_n", private, "<algorithm>", public ] },
-  { symbol: [ "std::filesystem::file_time_type", private, "<filesystem>", public ] },
+  { symbol: [ "std::pair", private, "<utility>", public ] },
+  { symbol: [ "std::vector", private, "<vector>", public ] },
+
 
   # libc++ aliases
   { include: [ "<__fwd/fstream.h>", private, "<fstream>", public ] },


### PR DESCRIPTION
- Add support for compiling with Clang-19 on Windows
- Fix bug for Windows hardening options where control flow guard wasn't applied to the linker flags
- Update Windows runners to `windows-2025`
- Change CI sanitizer builds to use RelWithDebInfo
- Change all CI builds to target x86_64 v3 architecture
- Fix various typos and consitencies