### PR TITLE
Update Cppcheck and fmt

### DIFF
--- a/.github/actions/install-cppcheck/action.yml
+++ b/.github/actions/install-cppcheck/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'Version to install'
     required: false
-    default: '2.17.1'
+    default: '2.18.0'
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,9 @@ jobs:
       - name: Checkout repository from github
         uses: actions/checkout@v4
 
-      - name: Install Clang and Ninja
+      - name: Install Ninja
         run: |
           choco install ninja
-          choco install llvm --version 20.1.2 -y
           
       - name: Setup Conan
         id: setup-conan

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ class CSTConan(ConanFile):
     implements = ["auto_shared_fpic"]
 
     def requirements(self):
-        self.requires("fmt/11.1.4")
+        self.requires("fmt/11.2.0")
 
     def build_requirements(self):
         self.tool_requires("cmake/[^3.27]")


### PR DESCRIPTION
- Update Cppcheck to 2.18.0
- Update fmt to 11.2.0
- Skip installation of Clang on Windows